### PR TITLE
Added condition to not flatten CURLFile objects, for PHP 5.5 and above

### DIFF
--- a/CURL.php
+++ b/CURL.php
@@ -305,7 +305,7 @@ class CURL {
         foreach ($array as $key => $value) {
             $name = $prefix ? "{$prefix}[{$key}]" : $key;
 
-            if (is_array($value) || is_object($value)) {
+            if (is_array($value) || (is_object($value) && get_class($value) != 'CURLFile')) {
                 $return += static::to_1_level_array($value, $name);
             }
             else {


### PR DESCRIPTION
Newer versions of PHP are moving to the [CURLFile syntax](http://php.net/manual/en/class.curlfile.php) for specifying file params, deprecating the @/path/ syntax.

This syntax causes issues when used with the to_1_level_array function in the Comvi CURL wrapper, as it flattens:

```
[file] => Array
        (
            [0] => CURLFile Object
                (
                    [name] => /.../Test/nda.docx
                    [mime] => 
                    [postname] => 
                )

        )
```

To:

```
[file[0][name]] => /Users/derek/Documents/sdks/hellosign-php-sdk/library/HelloSign/Test/nda.docx
 [file[0][mime]] => 
 [file[0][postname]] => 

```

which CURL does not understand.

This change simply passes the CURLFile object straight through, avoiding the issue.
Uploads using CURLFile objects work properly with this change.
